### PR TITLE
김갑경 / 15회차 / 2문제

### DIFF
--- a/김갑경/0401/BJ1629.java
+++ b/김갑경/0401/BJ1629.java
@@ -1,0 +1,38 @@
+import java.io.*;
+import java.util.*;
+
+// https://www.acmicpc.net/problem/1629
+// 곱셈
+public class BJ1629 {
+
+	private static long c;
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+
+		long a = parse(st.nextToken());
+		long b = parse(st.nextToken());
+		c = parse(st.nextToken());
+
+		System.out.println(find(a, b) % c);
+	}
+
+	private static long find(long a, long b) {
+		if (b <= 1)
+			return a % c;
+
+		long tmp = find(a, b / 2) % c;
+		long ans = (tmp * tmp) % c;
+
+		if (b % 2 == 0) {
+			return ans;
+		} else {
+			return (ans * a) % c;
+		}
+	}
+
+	private static long parse(String s) {
+		return Long.parseLong(s);
+	}
+}

--- a/김갑경/0401/BJ5214.java
+++ b/김갑경/0401/BJ5214.java
@@ -1,0 +1,74 @@
+import java.io.*;
+import java.util.*;
+
+// https://www.acmicpc.net/problem/5214
+// 환승
+public class BJ5214 {
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+
+		int n = parse(st.nextToken()); // 정점의 수 최대 10만
+		int k = parse(st.nextToken()); // 하이퍼튜브 하나로 연결하는 지점의 개수
+		int m = parse(st.nextToken()); // 하이퍼튜브 개수
+
+		boolean[] visitNode = new boolean[n + 1];
+		boolean[] visitTube = new boolean[m + 1];
+		int[][] station = new int[m][k];
+		List<Integer>[] adj = new ArrayList[n + 1]; // i번째 수가 있는 하이퍼튜브의 번호를 저장
+		for (int i = 1; i <= n; i++) {
+			adj[i] = new ArrayList<>();
+		}
+
+		while (m-- > 0) { // 하이퍼튜브
+			st = new StringTokenizer(br.readLine());
+			for (int i = 0; i < k; i++) {
+				station[m][i] = parse(st.nextToken());
+				adj[station[m][i]].add(m);
+			}
+		}
+
+		Queue<Integer> q = new LinkedList<>(); // bfs를 위한 큐
+
+		q.add(1);
+		visitNode[1] = true;
+
+		int t = 1;
+		while (!q.isEmpty()) {
+			int size = q.size();
+			for (int s = 0; s < size; s++) {
+				int now = q.poll();
+				if (now == n) {
+					System.out.println(t);
+					return;
+				}
+
+				// 현재 점이 있는 하이퍼튜브를 모두 탐색
+				for (int nextTube : adj[now]) {
+					if (visitTube[nextTube])
+						continue;
+
+					visitTube[nextTube] = true;
+					// 그 점이 있는 하이퍼튜브를 탐색하여 큐에 넣는다
+
+					for (int next : station[nextTube]) {
+						if (visitNode[next])
+							continue;
+
+						visitNode[next] = true;
+						q.offer(next);
+					}
+				}
+			}
+			t++;
+		}
+
+		System.out.println(-1);
+
+	}
+
+	private static int parse(String s) {
+		return Integer.parseInt(s);
+	}
+}


### PR DESCRIPTION
하: 고민을 많이 했던 문제입니다.
거듭제곱을 구해야하는데 C가 21억정도 까지라 21억번을 그대로 제곱해서 구하면 시간초과가 일어날 것입니다.
문제 분류의 이분탐색을 이용한 거듭제곱에서 힌트를 얻어서 분할정복 방식으로 풀었습니다.
최대 2^31까지의 연산을 분할정복을 이용해서 풀면 O(log2N)의 시간복잡도로 매우 줄어들게 됩니다.

상: BFS를 이용하여 풀었습니다.
다만 주어진 모든 연결정보를 이어버리면 시간초과, 메모리초과가 발생할것이기때문에 전부 저장해주지는 않고 1에서 출발하여 BFS를 진행해주었습니다.
하이퍼튜브 수가 1000, 하이퍼 튜브 내에 들어갈 수 있는 정점 수가 1000
1000^2 = 100만이기때문에 적어도 O(N)의 시간으로 해결해야 합니다. 즉, 하이퍼튜브를 한 번씩만 점검하고 넘어가야합니다.
그렇기 때문에 방문하는 정점 및 하이퍼튜브를 모두 체크해줄 visit배열을 따로 만들어서 한번씩만 체크할 수 있도록 해주고 BFS를 돌려서 구했습니다.