### PR TITLE
박상협 / 22회차 / 4문제

### DIFF
--- a/parksanghyeop/0426/Gold16719.java
+++ b/parksanghyeop/0426/Gold16719.java
@@ -1,0 +1,46 @@
+package gold;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class Gold16719 {
+
+	static String str;
+	static boolean[] visited;
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+		str = br.readLine();
+		visited = new boolean[str.length()];
+
+		find(0, str.length() - 1);
+
+	}
+
+	static void find(int start, int end) {
+
+		if (start > end)
+			return;
+
+		int index = end;
+
+		for (int i = start; i <= end; i++) {
+			if (str.charAt(index) > str.charAt(i))
+				index = i;
+		}
+
+		visited[index] = true;
+
+		for (int i = 0; i < str.length(); i++) {
+			if (visited[i])
+				System.out.print(str.charAt(i));
+		}
+		System.out.println();
+
+		find(index + 1, end);
+		find(start, index - 1);
+
+	}
+}

--- a/parksanghyeop/0426/Silver1181.java
+++ b/parksanghyeop/0426/Silver1181.java
@@ -1,0 +1,40 @@
+package silver;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+public class Silver1181 {
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		HashMap<String, Integer> wordMap = new HashMap<>();
+		List<String> list = new ArrayList<>();
+		
+		int N = Integer.parseInt(br.readLine());
+		
+		for(int i=0; i<N; i++) {
+			String word = br.readLine();
+			int length = word.length();
+			
+			wordMap.put(word, wordMap.getOrDefault(word, length));
+		}
+		
+		List<Map.Entry<String, Integer>> entryList = new LinkedList<>(wordMap.entrySet());
+	
+		entryList.sort(Map.Entry.comparingByKey());
+		entryList.sort(Map.Entry.comparingByValue());
+		
+		for(Map.Entry<String, Integer> entry : entryList) {
+			System.out.println(entry.getKey());
+		}			
+	}
+
+	
+
+}

--- a/parksanghyeop/0426/Silver2607.java
+++ b/parksanghyeop/0426/Silver2607.java
@@ -1,0 +1,61 @@
+package silver;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.HashMap;
+import java.util.Map;
+
+public class Silver2607 {
+
+	static Map<Character, Integer> first = new HashMap<>();
+	static Map<Character, Integer> compare = new HashMap<>();
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+		int count = 0;
+
+		int n = Integer.parseInt(br.readLine()) - 1;
+		String word = br.readLine();
+		int len = word.length();
+
+		init(first);
+		for (int i = 0; i < len; i++) {
+			char ch = word.charAt(i);
+			first.replace(ch, first.get(ch) + 1);
+		}
+
+		for (int i = 0; i < n; i++) {
+			init(compare);
+
+			word = br.readLine();
+			len = word.length();
+
+			for (int j = 0; j < len; j++) {
+				char ch = word.charAt(j);
+				compare.replace(ch, compare.get(ch) + 1);
+			}
+			if (similar(compare))
+				count++;
+		}
+		System.out.println(count);
+	}
+
+	static void init(Map<Character, Integer> temp) {
+		for (char ch = 'A'; ch <= 'Z'; ch++)
+			temp.put(ch, 0);
+	}
+
+	static boolean similar(Map<Character, Integer> temp) {
+		int a, b;
+		int diff = 0;
+		int firstLen = 0, compareLen = 0;
+		for (char ch = 'A'; ch <= 'Z'; ch++) {
+			firstLen += (a = first.get(ch));
+			compareLen += (b = temp.get(ch));
+			diff += Math.abs(a - b);
+		}
+		return diff <= 2 && Math.abs(firstLen - compareLen) <= 1;
+	}
+}

--- a/parksanghyeop/0426/Silver9081.java
+++ b/parksanghyeop/0426/Silver9081.java
@@ -1,0 +1,58 @@
+package silver;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+
+public class Silver9081 {
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+		int N = Integer.parseInt(br.readLine());
+
+		for (int i = 0; i < N; i++) {
+			System.out.println(find(br.readLine()));
+		}
+
+	}
+
+	static String find(String s) {
+		
+		// 길이가 1이면 바로 리턴
+		if (s.length() == 1)
+			return s;
+
+
+		int index = 0;
+		int min = 0;
+		// 오름차순이 깨지는곳을 찾는다
+		loop: for (index = s.length() - 2; index >= 0; index--) {
+			
+			// idx보다 큰거 확인
+			for (min = s.length() - 1; min > index; min--) {
+				if (s.charAt(index) < s.charAt(min))
+					break loop;
+			}
+		}
+
+		// 완전한 오름차순인 경우 내 뒤에 아무것도 없다
+		// 그니까 나 자신 리턴
+		if (index == -1)
+			return s;
+
+		char[] arr = s.toCharArray();
+
+		char temp = arr[min];
+		arr[min] = arr[index];
+		arr[index] = temp;
+
+		Arrays.sort(arr, index + 1, arr.length);
+
+		StringBuilder sb = new StringBuilder();
+		for (char c : arr)
+			sb.append(c);
+
+		return sb.toString();
+	}
+}


### PR DESCRIPTION
- **[1181 단어정렬]** : String으로 comparator를 쓰면 쉽게 풀리지만 Map으로 key value값을 모두 고려해서 정렬해본적이 없는거 같아서 연습삼아 풀어봤습니다.
  
- **[9081 단어 맞추기]** : 문자열 길이가 최대 99여서 완탐을 하면 시간초과가 납니다, 방법을 생각해내는데 시간이 오래걸린 문제입니다 주어진 문자열의 뒤에서 부터 탐색하면서 오름차순이 깨지는 곳을 찾는다는 아이디어를 떠올리면 쉽게 풀 수 있습니다.

- **[2607 비슷한 단어]** : 중복된 알파벳을 hash를 이용해 제거했을때 길이의 차이가 발생하거나 비교 문자와 사용된 알파벳이 다르면 뽑지 않으면 되는 간단한 문제입니다.

- **[16719 ZOAC]** : 가장 첫번째에 뽑은 문자를 기준으로 오른쪽 문자쪽을 전부 탐색하고 그 이후에 왼쪽을 탐색하는 방법으로 풀었습니다. 풀고보니 이분탐색과 유사하게 풀어진거 같습니다