### PR TITLE
김갑경 / 25회차 / 2문제

### DIFF
--- a/김갑경/0510/BJ1967.java
+++ b/김갑경/0510/BJ1967.java
@@ -1,0 +1,52 @@
+import java.io.*;
+import java.util.*;
+
+// https://www.acmicpc.net/problem/1967
+public class BJ1967 {
+
+	private static int ans;
+	private static ArrayList<Node>[] adj;
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+		int n = parse(br.readLine());
+		adj = new ArrayList[n + 1];
+		for (int i = 0; i <= n; i++) {
+			adj[i] = new ArrayList<>();
+		}
+
+		while (n-- > 1) {
+			StringTokenizer st = new StringTokenizer(br.readLine());
+			adj[parse(st.nextToken())].add(new Node(parse(st.nextToken()), parse(st.nextToken())));
+		}
+
+		go(1);
+		System.out.println(ans);
+	}
+
+	private static int go(int node) {
+		int[] max = new int[2];
+		for (Node next : adj[node]) {
+			max[0] = Math.max(max[0], go(next.n) + next.weight);
+			Arrays.sort(max);
+		}
+
+		ans = Math.max(ans, max[0] + max[1]);
+
+		return max[1];
+	}
+
+	private static class Node {
+		int n, weight;
+
+		Node(int n, int weight) {
+			this.n = n;
+			this.weight = weight;
+		}
+	}
+
+	private static int parse(String s) {
+		return Integer.parseInt(s);
+	}
+}

--- a/김갑경/0510/BJ20291.java
+++ b/김갑경/0510/BJ20291.java
@@ -1,0 +1,35 @@
+import java.io.*;
+import java.util.*;
+
+// https://www.acmicpc.net/problem/20291
+public class BJ20291 {
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+		Map<String, Integer> hm = new HashMap<>();
+
+		int n = Integer.parseInt(br.readLine());
+
+		while (n-- > 0) {
+			StringTokenizer st = new StringTokenizer(br.readLine(), ".");
+
+			st.nextToken();
+			String ext = st.nextToken();
+
+			if (hm.get(ext) == null) {
+				hm.put(ext, 1);
+			} else {
+				hm.put(ext, hm.get(ext) + 1);
+			}
+		}
+
+		Object[] mapkey = hm.keySet().toArray();
+
+		Arrays.sort(mapkey);
+
+		for (Object key : mapkey) {
+			System.out.println(key + " " + hm.get(key));
+		}
+	}
+}


### PR DESCRIPTION
1. 파일 정리
.을 기준으로 파싱만 해주면
해쉬 맵과 정렬을 이용하여 간단히 풀 수 있는 문제였습니다.
예전에 풀었던 생태학 문제랑 비슷하네요.

2. 트리의 지름
- 인접 리스트
우선 인접 리스트를 만들어줍니다.
루트 노드로부터 자식 노드로 탐색을 진행할건데, 문제의 입력에 무조건 `부모 노드 - 자식 노드 - 가중치`순으로 입력된다고 주어지기 때문에 `부모 → 자식`방향으로 단방향으로만 인접 리스트를 연결해주면 됩니다.

- 답 구하기
두 점을 찢었을 때 가장 길게 되는 길이를 구하면 됩니다.
그러면 한 부모 노드를 기준으로 자식 노드들 중 가장 긴 두 개의 합을 비교해주면 됩니다.
가장 긴 두 개를 비교하기 위해 크기 2짜리 배열을 만들고 정렬해주는 방식으로 진행했는데, 해당 부분은 조건문, 우선순위 큐 등등 다양한 방법으로 구현할 수 있을 것 같습니다.
만약 해당 부모 노드가 루트 노드(`1`)이 아니라면, 자식 노드의 길이 중 가장 긴 것에 자신의 부모 노드와 연결된 가중치를 더해서 올려보내주는식으로 `DFS`를 진행하면 됩니다.