### PR TITLE
한다빈 / 25회차 / 1문제

### DIFF
--- a/한다빈/0510/BOJ_20291_파일정리.java
+++ b/한다빈/0510/BOJ_20291_파일정리.java
@@ -1,0 +1,32 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class BOJ_20291_파일정리 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br= new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(br.readLine());
+        HashMap<String, Integer> map = new HashMap<>();
+
+        for (int i = 0; i < N; i++) {
+            String s = br.readLine();
+            String[] sSplit = s.split("\\."); //.을 기준으로 끊기
+
+            if (map.containsKey(sSplit[1])) {
+                // 해쉬맵에 존재하면 숫자만 바꾸기
+                map.replace(sSplit[1], map.get(sSplit[1])+1);
+            } else {
+                // 존재하지 않으면 넣기
+                map.put(sSplit[1], 1);
+            }
+        }
+        List<String> arr = new ArrayList<>(map.keySet());
+        Collections.sort(arr);
+
+        for (String key : arr) {
+            System.out.println(key + " " + map.get(key));
+        }
+
+    }
+}


### PR DESCRIPTION
하 : 20291 파일정리
split 사용해서 문자열을 끊을때 .은 바로 안끊어집니다 -> //.이라고 써야 끊어짐을 알게됐습니다.

맨처음엔 arr[] 배열을 사용해서 값을 넣고, 정렬을 한뒤에 해쉬맵에 넣는 코드를 썼다가,
해쉬맵에 넣고 카운트까지 완료한다음에 -> ArrayList에 넣고 정렬하는 방법이 깔끔해서 이렇게 풀었더니 풀렸습니다!